### PR TITLE
Option to add end_date to historical data

### DIFF
--- a/Generate_graph.py
+++ b/Generate_graph.py
@@ -12,13 +12,19 @@ logger = logging.getLogger(__name__)
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("country_iso3", help="Country ISO3")
+    parser.add_argument(
+        "--end_date",
+        default=None,
+        type=str,
+        help="Last date to include in graph, equals start date of Bucky simulation. Passed in as string, formatted as YYYY-MM-DD. If not passed in, will take max date in covid data"
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
     try:
-        graph(args.country_iso3.upper())
+        graph(args.country_iso3.upper(),args.end_date)
     except:
         logger.error(
             f"Cannot generate graph file, check log for details"


### PR DESCRIPTION
Resolving issue #100 

Adding an args to define end_date for historical subnational and WHO covid data
All the other input (e.g. NPIs) are from the current file in the directory, so no checking for dates there with the current addition.